### PR TITLE
Inject additional player information into new page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*.code-workspace

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -38,10 +38,9 @@
             ]
         },
         {
-            "matches": ["https://csgo.99damage.de/de/leagues/teams/*"],
+            "matches": ["https://liga.99damage.de/de/leagues/teams*"],
             "js": [
-                "scripts/teampage/members/content.js",
-                "scripts/teampage/maps/content.js"
+                "scripts/teampage/members/content.js"
             ]
         }
     ],
@@ -57,6 +56,7 @@
         "https://open.faceit.com/*",
         "https://steamcommunity.com/profiles/*",
         "https://csgo.99damage.de/*",
+        "https://liga.99damage.de/*",
         "storage",
         "unlimitedStorage"
     ],


### PR DESCRIPTION
With the new page, there is no longer a player dable, instead each member has their own card.
This PR implementes the previously available information of Faceit Elo/Level/Link and Steam Name/Link into the new design.
The average faceit elo of the team is also injected into the new layout.

Resolves #1 