### PR TITLE
Replace unnecessary innerHTML usage with textContent

### DIFF
--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -27,7 +27,7 @@ function addFlashkillNavigationButton() {
 
     const teamSucheLi = document.createElement("li");
     const teamSucheA = document.createElement("a");
-    teamSucheA.innerHTML = "Teamsuche";
+    teamSucheA.textContent = "Teamsuche";
     teamSucheA.addEventListener("click", () => {
         const currentActive = document.getElementsByClassName("active");
         if (currentActive != null && currentActive.length > 0) {

--- a/src/scripts/resultsgetter.js
+++ b/src/scripts/resultsgetter.js
@@ -11,12 +11,12 @@ var teamName;
 var teamShorthand;
 
 function insertResultsTable(container, seasonTd, teamName, teamShorthand, season) {
-    container.innerHTML = "Ergebnisse werden geladen...";
+    container.textContent = "Ergebnisse werden geladen...";
     chrome.runtime.sendMessage(
         { contentScriptQuery: "queryMatches", linkInformation: buildLinkInformation(seasonTd), teamName, teamShorthand },
         matches => {
             if (matches.length == 0) {
-                container.innerHTML = "Keine Ergebnisse gefunden.";
+                container.textContent = "Keine Ergebnisse gefunden.";
             } else {
                 const table = document.createElement("table");
                 table.className = "display";
@@ -39,7 +39,7 @@ function insertResultsTable(container, seasonTd, teamName, teamShorthand, season
                 linkCell.outerHTML = "<th>Matchroom</th>";
 
                 const body = table.createTBody();
-                container.innerHTML = "";
+                container.textContent = "";
                 container.appendChild(table);
                 matches.filter(match => match.mapResults.length > 0).flatMap(match => match.mapResults).map(map => {
                     var row = body.insertRow(0);
@@ -85,7 +85,7 @@ function buildLinkInformation(seasonTd) {
         return {
             seasonUrl: links[0].href,
             additionalUrl: links[1].href,
-            additionalInfo: links[1].innerHTML
+            additionalInfo: links[1].textContent
         }
     }
     return {
@@ -111,23 +111,23 @@ function fillMapRow(row, mapResult) {
     const map = row.insertCell(-1);
     const link = row.insertCell(-1);
     date.setAttribute("data-sort", mapResult.date);
-    date.innerHTML = formatDate(mapResult.date);
+    date.textContent = formatDate(mapResult.date);
     if (mapResult.additionalInfo != null) {
-        date.innerHTML = date.innerHTML + " " + mapResult.additionalInfo;
+        date.textContent = date.textContent + " " + mapResult.additionalInfo;
     }
     const team1A = document.createElement("a");
-    team1A.innerHTML = mapResult.team1;
+    team1A.textContent = mapResult.team1;
     team1A.href = mapResult.team1Link;
     team1A.target = "_blank";
     team1.appendChild(team1A);
     const team2A = document.createElement("a");
-    team2A.innerHTML = mapResult.team2;
+    team2A.textContent = mapResult.team2;
     team2A.href = mapResult.team2Link;
     team2A.target = "_blank";
     team2.appendChild(team2A);
-    score1.innerHTML = mapResult.scoreTeam1;
-    score2.innerHTML = mapResult.scoreTeam2;
-    map.innerHTML = mapResult.map;
+    score1.textContent = mapResult.scoreTeam1;
+    score2.textContent = mapResult.scoreTeam2;
+    map.textContent = mapResult.map;
     const mapImageLink = getMapImage(mapResult.map);
     map.style = `
         background-image:url(${mapImageLink});
@@ -139,7 +139,7 @@ function fillMapRow(row, mapResult) {
     const linkA = document.createElement("a");
     linkA.href = mapResult.link;
     linkA.target = "_blank";
-    linkA.innerHTML = "mehr";
+    linkA.textContent = "mehr";
     link.appendChild(linkA);
 }
 

--- a/src/scripts/saison.js
+++ b/src/scripts/saison.js
@@ -7,7 +7,7 @@ function insertTeamSearch() {
     const seasonSelectDivs = Array.from(document.getElementById("content").getElementsByTagName("div")).filter(element => {
         const elements = element.getElementsByTagName("select");
         return elements.length == 1
-        && elements[0].getElementsByTagName("option")[0].innerHTML == "Saison 1";
+        && elements[0].getElementsByTagName("option")[0].textContent == "Saison 1";
     });
 
     seasonSelectDivs.forEach(element => {
@@ -30,17 +30,17 @@ function insertTeamSearchTable(element) {
 
 function getTeamSearchButton() {
     const teamsucheA = document.createElement("a");
-    teamsucheA.innerHTML = "Teamsuche";
+    teamsucheA.textContent = "Teamsuche";
     teamsucheA.addEventListener("click", () => {
         const teamtableDiv = document.getElementById("team-table-div");
         if (teamsucheToggled == false) {
             const seasonUrl = window.location.href;
             insertTeamTable(teamtableDiv, seasonUrl);
-            teamsucheA.innerHTML = "Teamsuche ausblenden";
+            teamsucheA.textContent = "Teamsuche ausblenden";
             teamsucheToggled = true;
         } else {
-            teamtableDiv.innerHTML = "";
-            teamsucheA.innerHTML = "Teamsuche";
+            teamtableDiv.textContent = "";
+            teamsucheA.textContent = "Teamsuche";
             teamsucheToggled = false;
         }
     })

--- a/src/scripts/teampage/maps/content.js
+++ b/src/scripts/teampage/maps/content.js
@@ -20,16 +20,16 @@ function insertMapsButton() {
 
 function getMapsButton() {
     const mapsButton = document.createElement("a");
-    mapsButton.innerHTML = "Map Übersicht (BETA) anzeigen";
+    mapsButton.textContent = "Map Übersicht (BETA) anzeigen";
     mapsButton.addEventListener("click", () => {
         if (mapsTableShown == false) {
             const seasonUrl = "";
             insertMapsTable();
-            mapsButton.innerHTML = "Map Übersicht (BETA) ausblenden";
+            mapsButton.textContent = "Map Übersicht (BETA) ausblenden";
             mapsTableShown = true;
         } else {
             removeMapsTable();
-            mapsButton.innerHTML = "Map Übersicht (BETA) anzeigen";
+            mapsButton.textContent = "Map Übersicht (BETA) anzeigen";
             mapsTableShown = false;
         }
     })
@@ -91,7 +91,7 @@ function getConsensusSelection(season) {
 }
 
 function getSeasonConsensus(seasonName) {
-    const seasonConsensusString = document.getElementById(`${seasonName} Consensus`).innerHTML;
+    const seasonConsensusString = document.getElementById(`${seasonName} Consensus`).textContent;
     const seasonConsensusValue = seasonConsensusString.replace(/%/g, "");
     return seasonConsensusValue;
 }
@@ -163,7 +163,7 @@ function buildTable(mapInfos) {
 
         const row = body.insertRow(-1);
         const mapCell = row.insertCell(-1);
-        mapCell.innerHTML = map;
+        mapCell.textContent = map;
         mapCell.style = "background-image:url(" + getMapImage(map) + "); text-align:center; background-size:cover; color:#fff; text-shadow:0 0 4px #000, 0px 0 4px #000, 0px 0 3px #000"
         insertCell(row, percentageMapPlayed, countMapPlayed, "Das Team spielte " + map + " " + countMapPlayed + " mal.");
         insertCell(row, percentagePicked, countPicked, map + " war zum Pickzeitpunkt noch " + countPickable + " mal pickbar und " + countPicked + " mal davon pickte das Team die Map.", countPickable);
@@ -207,7 +207,7 @@ function makeMultiselect(selectId, mapInfosPerSeason) {
 function insertHeading(filter) {
     const heading = document.createElement("h2");
     heading.id = ("maps-table-header");
-    heading.innerHTML = "Map Übersicht (BETA)";
+    heading.textContent = "Map Übersicht (BETA)";
     filter.parentNode.insertBefore(heading, filter);
 }
 
@@ -230,7 +230,7 @@ function addSeasonsToFilter(select, mapInfosPerSeason) {
 function addSeasonToFilter(select, mapInfoPerSeason) {
     const option = document.createElement("option");
     option.value = mapInfoPerSeason.seasonName;
-    option.innerHTML = mapInfoPerSeason.seasonName;
+    option.textContent = mapInfoPerSeason.seasonName;
     option.selected = mapInfoPerSeason.preSelection;
     select.appendChild(option);
 }
@@ -278,9 +278,9 @@ function insertCell(row, percentage, absolute, title, fromAbsolute = null) {
     cell.setAttribute("data-sort", absolute);
     cell.setAttribute("title", title);
     if (fromAbsolute) {
-        cell.innerHTML = formatPercentageWithAbsoluteAndFromAbsolute(percentage, absolute, fromAbsolute);
+        cell.textContent = formatPercentageWithAbsoluteAndFromAbsolute(percentage, absolute, fromAbsolute);
     } else {
-        cell.innerHTML = formatPercentageWithAbsolute(percentage, absolute);
+        cell.textContent = formatPercentageWithAbsolute(percentage, absolute);
     }
 }
 

--- a/src/scripts/teampage/members/content.js
+++ b/src/scripts/teampage/members/content.js
@@ -16,7 +16,7 @@ async function getSeasonStartAndEndDates(seasonUrl) {
     const text = await response.text();
     const seasonDocument = new DOMParser().parseFromString(text, "text/html"); 
     const seasonNameElements = seasonDocument.evaluate(SEASON_NAME_XPATH_EXPRESSION, seasonDocument, null, XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null); 
-    const seasonName = seasonNameElements.snapshotItem(0).innerHTML;
+    const seasonName = seasonNameElements.snapshotItem(0).textContent;
     if (seasonName == "Saison 12") {
         return new Season(seasonName, new Date(Date.now()), new Date(Date.now()));
     }
@@ -34,17 +34,17 @@ function improveResultsTable() {
     const tableHead = document.createElement("thead");
     const headerTr = document.createElement("tr");
     const seasonTh = document.createElement("th");
-    seasonTh.innerHTML = "Saison";
+    seasonTh.textContent = "Saison";
     headerTr.appendChild(seasonTh);
     const divisionTh = document.createElement("th");
-    divisionTh.innerHTML = "Division";
+    divisionTh.textContent = "Division";
     headerTr.appendChild(divisionTh);
     const resultsTh = document.createElement("th");
-    resultsTh.innerHTML = "Ergebnisse";
+    resultsTh.textContent = "Ergebnisse";
     resultsTh.colSpan = "2";
     headerTr.appendChild(resultsTh);
     const konsensTh = document.createElement("th");
-    konsensTh.innerHTML = "Konsens";
+    konsensTh.textContent = "Konsens";
     konsensTh.title = "Anteil des aktuellen Linups, das während dieser Saison in diesem Team gespielt hat.";
     headerTr.appendChild(konsensTh);
     tableHead.appendChild(headerTr);
@@ -66,7 +66,7 @@ function insertMembersPerSeason() {
             const seasonTr = resultsTableRows[i];
             const seasonName = seasonTr.firstChild.nextSibling.innerText;
             konsensTd.id = `${seasonName} Consensus`;
-            konsensTd.innerHTML = getConsensusFromSeasonMembers(seasonMembers[i])+"%";
+            konsensTd.textContent = getConsensusFromSeasonMembers(seasonMembers[i])+"%";
             konsensTd.title = seasonMembers[i].join(", ");
             konsensTd.style.verticalAlign = "top";
             konsensTd.align = "center";
@@ -123,21 +123,21 @@ function getRelevantTeamLogRows(members) {
     Array.from(teamLogRows).forEach(log => {
         const logElements = log.getElementsByTagName("td");
         if (logElements.length == 4) {
-        if (logElements[2].innerHTML == "create") {
-            if (members.includes(logElements[1].innerHTML)) {
-                relevantLogs.push({date: new Date(getDateFromTeamLogEntry(logElements[0])), member: logElements[1].innerHTML, action: "join"});
+        if (logElements[2].textContent == "create") {
+            if (members.includes(logElements[1].textContent)) {
+                relevantLogs.push({date: new Date(getDateFromTeamLogEntry(logElements[0])), member: logElements[1].textContent, action: "join"});
             }
-        } else if (logElements[2].innerHTML == "member_join") {
-            if (members.includes(logElements[1].innerHTML)) {
-                relevantLogs.push({date: new Date(getDateFromTeamLogEntry(logElements[0])), member: logElements[1].innerHTML, action: "join"});
+        } else if (logElements[2].textContent == "member_join") {
+            if (members.includes(logElements[1].textContent)) {
+                relevantLogs.push({date: new Date(getDateFromTeamLogEntry(logElements[0])), member: logElements[1].textContent, action: "join"});
             }
-        } else if (logElements[2].innerHTML == "member_leave") {
-            if (members.includes(logElements[1].innerHTML)) {
-                relevantLogs.push({date: new Date(getDateFromTeamLogEntry(logElements[0])), member: logElements[1].innerHTML, action: "leave"});
+        } else if (logElements[2].textContent == "member_leave") {
+            if (members.includes(logElements[1].textContent)) {
+                relevantLogs.push({date: new Date(getDateFromTeamLogEntry(logElements[0])), member: logElements[1].textContent, action: "leave"});
             }
-        } else if (logElements[2].innerHTML == "member_kick") {
-            if (members.includes(logElements[3].innerHTML)) {
-                relevantLogs.push({date: new Date(getDateFromTeamLogEntry(logElements[0])), member: logElements[3].innerHTML, action: "leave"});
+        } else if (logElements[2].textContent == "member_kick") {
+            if (members.includes(logElements[3].textContent)) {
+                relevantLogs.push({date: new Date(getDateFromTeamLogEntry(logElements[0])), member: logElements[3].textContent, action: "leave"});
             }
         }
         }
@@ -164,7 +164,7 @@ async function getMembersPerSeason() {
         return getSeasonStartAndEndDates(seasonUrl);
     }));
     //Get each Member
-    const teamMembers = Array.from(document.getElementById("member-table").getElementsByTagName("tbody")[0].getElementsByTagName("tr")).map(member => member.getElementsByTagName("td")[2].firstChild.innerHTML);
+    const teamMembers = Array.from(document.getElementById("member-table").getElementsByTagName("tbody")[0].getElementsByTagName("tr")).map(member => member.getElementsByTagName("td")[2].firstChild.textContent);
     //Get all Memberships for Members
     const membershipsMembers = getMemberships(teamMembers);
     //Check for each season if Member had membership during timeframe update Season with Membername
@@ -241,7 +241,7 @@ class Season {
 
 function insertFaceitEloMean(faceitEloMean) {
     const faceitEloMeanH2 = document.createElement("h2");
-    faceitEloMeanH2.innerHTML = "FACEIT Elo: " + Math.round(faceitEloMean);
+    faceitEloMeanH2.textContent = "FACEIT Elo: " + Math.round(faceitEloMean);
     faceitEloMeanH2.title = "Durchschnittliche FACEIT Elo";
     const teamHeader = document.getElementsByClassName("content-portrait-head")[0];
     teamHeader.parentNode.appendChild(faceitEloMeanH2);
@@ -290,7 +290,7 @@ function inject(playerInfo, memberCard) {
         steamDiv.style = "padding-top:5px;"
         const steamLink = document.createElement("a");
         steamLink.href = `https://steamcommunity.com/profiles/${steamId64}`;
-        steamLink.innerHTML = playerInfo.steamName;
+        steamLink.textContent = playerInfo.steamName;
         steamLink.target = "_blank";
 
         steamDiv.appendChild(steamLink);
@@ -324,7 +324,7 @@ function inject(playerInfo, memberCard) {
         const eloTd = document.createElement("td");
         const eloDiv = document.createElement("div");
         eloDiv.className = "txt-subtitle";
-        eloDiv.innerHTML = `FACEIT: ${faceitInfo.games.csgo.faceit_elo}`;
+        eloDiv.textContent = `FACEIT: ${faceitInfo.games.csgo.faceit_elo}`;
 
         eloTd.appendChild(eloDiv);
 
@@ -347,7 +347,7 @@ function getFaceitLink(name) {
 }
 
 function getSteamId(memberCard) {
-    return memberCard.getElementsByTagName("span")[0].innerHTML;
+    return memberCard.getElementsByTagName("span")[0].textContent;
 }
 
 function getNumberOfSeasons() {
@@ -371,13 +371,13 @@ function insertSeasonResultsButtonInto(element, i) {
 
 function getTeamName() {
     const teamNameH2 = document.getElementsByTagName("h2")[0];
-    const teamName = teamNameH2.innerHTML.split("(")[0];
+    const teamName = teamNameH2.textContent.split("(")[0];
     return teamName.trim();
 }
 
 function getTeamShorthand() {
     const teamNameH2 = document.getElementsByTagName("h2")[0];
-    const teamShorthandRaw = teamNameH2.innerHTML.split("(")[1];
+    const teamShorthandRaw = teamNameH2.textContent.split("(")[1];
     const teamShorthand = teamShorthandRaw.substring(0, teamShorthandRaw.length-1);
     return teamShorthand.trim();
 }
@@ -416,16 +416,16 @@ function getActualTableIndexForSeason(season) {
 
 function getSeasonResultsButton(season) {
     const seasonResult = document.createElement("a");
-    seasonResult.innerHTML = "Ergebnisse anzeigen";
+    seasonResult.textContent = "Ergebnisse anzeigen";
     seasonResult.addEventListener("click", () => {
         if (seasonResultsToggled[season] == false) {
             const seasonUrl = "";
             insertSeasonResults(season);
-            seasonResult.innerHTML = "Ergebnisse ausblenden";
+            seasonResult.textContent = "Ergebnisse ausblenden";
             seasonResultsToggled[season] = true;
         } else {
             removeSeasonResults(season);
-            seasonResult.innerHTML = "Ergebnisse anzeigen";
+            seasonResult.textContent = "Ergebnisse anzeigen";
             seasonResultsToggled[season] = false;
         }
     })

--- a/src/scripts/teampage/teams/content.js
+++ b/src/scripts/teampage/teams/content.js
@@ -1,7 +1,7 @@
 const DEFAULT_SEASON_URL = "https://csgo.99damage.de/de/leagues/99dmg/1360-saison-12";
 
 function insertTeamTable(container, seasonUrl = DEFAULT_SEASON_URL) {
-    container.innerHTML = "Teamtabelle wird geladen...";
+    container.textContent = "Teamtabelle wird geladen...";
     chrome.runtime.sendMessage(
         { contentScriptQuery: "queryTeams", seasonUrl },
         teams => {
@@ -27,24 +27,24 @@ function insertTeamTable(container, seasonUrl = DEFAULT_SEASON_URL) {
                 const row = body.insertRow(0);
                 const team = row.insertCell(-1);
                 const teamA = document.createElement("a");
-                teamA.innerHTML = entry.name;
+                teamA.textContent = entry.name;
                 teamA.target = "_blank";
                 teamA.href = entry.link;
                 team.appendChild(teamA);
                 const division = row.insertCell(-1);
                 const divisionA = document.createElement("a");
-                divisionA.innerHTML = entry.divisionName;
+                divisionA.textContent = entry.divisionName;
                 divisionA.target = "_blank";
                 divisionA.href = entry.divisionLink;
                 division.appendChild(divisionA);
                 const mapsWon = row.insertCell(-1);
-                mapsWon.innerHTML = entry.mapsWon;
+                mapsWon.textContent = entry.mapsWon;
                 const mapsLost = row.insertCell(-1);
-                mapsLost.innerHTML = entry.mapsLost;
+                mapsLost.textContent = entry.mapsLost;
                 const rounds = row.insertCell(-1);
-                rounds.innerHTML = entry.rounds
+                rounds.textContent = entry.rounds
             })
-            container.innerHTML = "";
+            container.textContent = "";
             container.appendChild(table);
             $('#team-table').DataTable({
                 pageLength: 50,


### PR DESCRIPTION
Resolves #12 by not assigning any unsanitized data to `innerHTML` anymore.  Additionally I switched to `textContent` in all other occurrences as `innerHTML`, not only assignments, as we were only using it to read and assign text. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) `textContent` is a better choice for that, as it is more performant. The MDN post also mentions `innerText`, which might be a preffered option for some use cases. We should be aware of that in new implementations. However, in this refactor of `innerHTML` I did not consider it to ensure the exact same functionallity.