### PR TITLE
Improve season results header

### DIFF
--- a/src/scripts/team-page/seasons/content.js
+++ b/src/scripts/team-page/seasons/content.js
@@ -86,7 +86,13 @@ function insertSeasonResults(season) {
     seasonDiv.className = "section-content";
     const seasonHeader = document.createElement("div");
     seasonHeader.textContent = season.name;
-    seasonHeader.className = "txt-subtitle";
+    seasonHeader.style = "color: black; font-size: 16px; font-weight: bold";
+    const providedByFlashkillSpan = document.createElement("a");
+    providedByFlashkillSpan.style = "color: grey; float: right; font-size: 10px; font-weight: normal; font-style: italic";
+    providedByFlashkillSpan.textContent = "provided by flashkill";
+    providedByFlashkillSpan.href = "https://github.com/flashkillapp/flashkill";
+    providedByFlashkillSpan.target = "_blank";
+    seasonHeader.appendChild(providedByFlashkillSpan);
     seasonDiv.appendChild(seasonHeader);
 
     matches = season.matches;


### PR DESCRIPTION
* Resolves #17 by adding the flashkill logo with a link to the github repository.
* I also went and slightly improved the season header font.

![image](https://user-images.githubusercontent.com/4618507/83339202-bc557780-a2cb-11ea-9bcf-afa7f9963da6.png)

