### PR TITLE
Add team search button to nav

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -12,12 +12,17 @@
     },
     "content_scripts": [
         {
+            "matches": ["https://liga.99damage.de/*"],
+            "js": [
+                "content.js"
+            ]
+        },
+        {
             "matches": ["https://liga.99damage.de/de/leagues/teams*"],
             "js": [
                 "thirdParty/jquery-3.4.0.min.js",
                 "thirdParty/jquery.dataTables.js",
-                "thirdParty/jquery.multiselect.js",
-                "content.js"
+                "thirdParty/jquery.multiselect.js"
             ],
             "css": [
                 "thirdParty/jquery.multiselect.css",

--- a/src/content.js
+++ b/src/content.js
@@ -12,5 +12,5 @@ function addTeamsButton() {
     const teamsLi = document.createElement("li");
     teamsLi.appendChild(teamsA);
 
-    teamsLi.parentNode.insertBefore(teamsLi, nextLi);
+    nextLi.parentNode.insertBefore(teamsLi, nextLi);
 }

--- a/src/content.js
+++ b/src/content.js
@@ -1,9 +1,8 @@
 addTeamsButton();
 
 function addTeamsButton() {
-    const headerNavUl = document.querySelector("#header-nav > nav > ul");
     const nextLi = document.querySelector("#header-nav > nav > ul > li:nth-child(3)");
-    if (!headerNavUl || !nextLi) {
+    if (!nextLi) {
         return;
     }
 
@@ -13,5 +12,5 @@ function addTeamsButton() {
     const teamsLi = document.createElement("li");
     teamsLi.appendChild(teamsA);
 
-    headerNavUl.insertBefore(teamsLi, nextLi);
+    teamsLi.parentNode.insertBefore(teamsLi, nextLi);
 }

--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,17 @@
+addTeamsButton();
+
+function addTeamsButton() {
+    const headerNavUl = document.querySelector("#header-nav > nav > ul");
+    const nextLi = document.querySelector("#header-nav > nav > ul > li:nth-child(3)");
+    if (!headerNavUl || !nextLi) {
+        return;
+    }
+
+    const teamsA = document.createElement("a");
+    teamsA.href = "https://liga.99damage.de/de/leagues/teams";
+    teamsA.textContent = "Teams";
+    const teamsLi = document.createElement("li");
+    teamsLi.appendChild(teamsA);
+
+    headerNavUl.insertBefore(teamsLi, nextLi);
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,7 @@ const backgroundConfig = {
 
 const contentConfig = {
     entry: [
+        './src/content.js',
         './src/team-page/members/content.js',
         './src/team-page/seasons/content.ts',
     ],


### PR DESCRIPTION
fixes #15 by adding a button "Teams" to the top navigation bar at liga.99damage.de
it also removes obsolete code that is no longer needed from the main page (csgo.99damage.de). the function insertDataTablesCss() is still in the code, it can be found in scripts\util\content\util.js, which is used by all other scripts anway. it's not needed for adding the teams button, hence removed from that file.