### PR TITLE
Fix consensus for the new league page

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -24,8 +24,8 @@
                 "thirdParty/jquery.dataTables.js",
                 "thirdParty/tooltipster.bundle.min.js",
                 "thirdParty/jquery.multiselect.js",
-                "content/team-page/members/content.js",
-                "content/team-page/seasons/content.js"
+                "content/team-page/members/index.js",
+                "content/team-page/seasons/index.js"
             ],
             "css": [
                 "thirdParty/jquery.multiselect.css",

--- a/src/team-page/members/content.ts
+++ b/src/team-page/members/content.ts
@@ -1,90 +1,36 @@
 
-var seasonResultsToggled = new Array(15).fill(false);
+import { Season } from "../seasons/content";
+import { MemberRequestTypes, getSteamLink, PlayerInfo } from "./background";
 
-const SEASON_START_DATE_XPATH_EXPRESSION = "//table[@class='league_table_matches']/tbody/tr[2]/td[1]/a";
-const SEASON_END_DATE_XPATH_EXPRESSION = "//table[@class='league_table_matches']/tbody/tr[last()]/td[1]/a";
-const SEASON_NAME_XPATH_EXPRESSION = "//div[@class='l2']";
-const MEMBER_LIST_XPATH_EXPRESSION = "//ul[@class='content-portrait-grid-l']/li";
-
-// improveMemberTable();
-
-// improveResultsTable();
+const MEMBER_NAMES_XPATH_EXPRESSION = "//*[@id='container']/main/section[2]/div[3]/ul/li/a[2]/h3";
+const TEAM_LOG_ROWS_XPATH_EXPRESSION = "//*[@id='container']/main/section[4]/div/div/div[2]/table/tbody/tr";
 
 improveMemberCards();
 
-async function getSeasonStartAndEndDates(seasonUrl) {
-    //TODO: fetch Logik in background.js
-    const response = await fetch(seasonUrl);
-    const text = await response.text();
-    const seasonDocument = new DOMParser().parseFromString(text, "text/html"); 
-    const seasonNameElements = seasonDocument.evaluate(SEASON_NAME_XPATH_EXPRESSION, seasonDocument, null, XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null); 
-    const seasonName = seasonNameElements.snapshotItem(0).textContent;
-    if (seasonName == "Saison 12") {
-        return new SeasonBounds(seasonName, new Date(Date.now()), new Date(Date.now()));
-    }
-    const startDateRawElements = seasonDocument.evaluate(SEASON_START_DATE_XPATH_EXPRESSION, seasonDocument, null, XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null); 
-    const endDateRawElements = seasonDocument.evaluate(SEASON_END_DATE_XPATH_EXPRESSION, seasonDocument, null, XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null); 
-    const startDateRaw = startDateRawElements.snapshotItem(0).textContent.trim();
-    const endDateRaw = endDateRawElements.snapshotItem(0).textContent.trim();
-    var startDate = new Date(formatDateToStandard(startDateRaw));
-    startDate.setDate(startDate.getDate() - 7);
-    return new SeasonBounds(seasonName, new Date(startDate), new Date(formatDateToStandard(endDateRaw)));
-}
-
-function improveResultsTable() {
-    const resultsTable = document.getElementById("content").getElementsByTagName("table")[1];
-    const tableHead = document.createElement("thead");
-    const headerTr = document.createElement("tr");
-    const seasonTh = document.createElement("th");
-    seasonTh.textContent = "Saison";
-    headerTr.appendChild(seasonTh);
-    const divisionTh = document.createElement("th");
-    divisionTh.textContent = "Division";
-    headerTr.appendChild(divisionTh);
-    const resultsTh = document.createElement("th");
-    resultsTh.textContent = "Ergebnisse";
-    resultsTh.colSpan = 2;
-    headerTr.appendChild(resultsTh);
-    const konsensTh = document.createElement("th");
-    konsensTh.textContent = "Konsens";
-    konsensTh.title = "Anteil des aktuellen Linups, das während dieser Saison in diesem Team gespielt hat.";
-    headerTr.appendChild(konsensTh);
-    tableHead.appendChild(headerTr);
-    resultsTable.appendChild(tableHead);
-    insertSeasonResultsButtons();
-    insertMembersPerSeason();
-}
-
 function getConsensusFromSeasonMembers(seasonMembers) {
-    const teamMembers = document.getElementById("member-table").getElementsByTagName("tbody")[0].getElementsByTagName("tr");
-    return Math.round(100*(seasonMembers.length/teamMembers.length));
+    const teamMemberEntries = document.evaluate(MEMBER_NAMES_XPATH_EXPRESSION, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+    return Math.round(100*(seasonMembers.length/teamMemberEntries.snapshotLength));
 }
 
-function insertMembersPerSeason() {
-    getMembersPerSeason().then(seasonMembers => {
-        const resultsTableRows = document.getElementById("content").getElementsByTagName("table")[2].getElementsByTagName("tbody")[0].getElementsByTagName("tr");
-        for (var i = 0; i < seasonMembers.length; i++) {
-            const konsensTd = document.createElement("td");
-            const seasonTr = resultsTableRows[i];
-            const seasonName = seasonTr.firstChild.nextSibling.textContent;
-            konsensTd.id = `${seasonName} Consensus`;
-            konsensTd.textContent = getConsensusFromSeasonMembers(seasonMembers[i])+"%";
-            konsensTd.title = seasonMembers[i].join(", ");
-            konsensTd.style.verticalAlign = "top";
-            konsensTd.align = "center";
-            seasonTr.appendChild(konsensTd);
-        }
-    });
+export function getConsensDiv(season: Season) : HTMLDivElement {
+    const seasonMembers = getMembersPerSeason(season);
+    const konsensDiv = document.createElement("div");
+
+    konsensDiv.id = `${season.name} Consensus`;
+    konsensDiv.textContent = `Konsens: ${getConsensusFromSeasonMembers(seasonMembers)}%`;
+    konsensDiv.title = seasonMembers.join(", ");
+    konsensDiv.style.verticalAlign = "top";
+
+    return konsensDiv;
 }
 
-function getDateFromTeamLogEntry(dateTd) {
-    var dateStringRaw = dateTd.firstChild.title;
-    dateStringRaw = dateStringRaw.substring(5, 16);
-    dateStringRaw = formatDateToStandard(dateStringRaw);
+function getDateFromTeamLogEntry(dateTd: HTMLTableDataCellElement) : Date {
+    var dateContent = dateTd.getElementsByTagName("span")[0].getElementsByTagName("span")[0];
+    var dateStringRaw = dateContent.title;
     return new Date(dateStringRaw);
 }
 
-function compareTeamLogEntries( a, b ) {
+function compareTeamLogEntries(a: MemberAction, b: MemberAction) : number {
   if ( a.date < b.date ){
     return -1;
   }
@@ -94,19 +40,25 @@ function compareTeamLogEntries( a, b ) {
   return 0;
 }
 
-function getMemberships(members) {
-    const relevantRows = getRelevantTeamLogRows(members);
+interface Membership {
+    member: string;
+    startDate: Date;
+    endDate: Date;
+}
+
+function getMemberships(members: string[]) : Membership[] {
+    const memberActions = getRelevantTeamLogRows(members);
     var memberships = new Array();
-    for (var i = 0; i < relevantRows.length; i++) {
-        if (relevantRows[i].action == "join") {
-            const currentMember = relevantRows[i].member;
-            for (var j = i; j <= relevantRows.length; j++) {
-                if (j == relevantRows.length) {
-                    memberships.push({member: currentMember, startDate: relevantRows[i].date, endDate: new Date(Date.now())});
+    for (var i = 0; i < memberActions.length; i++) {
+        if (memberActions[i].action === Action.Join) {
+            const currentMember = memberActions[i].member;
+            for (var j = i; j <= memberActions.length; j++) {
+                if (j === memberActions.length) {
+                    memberships.push({member: currentMember, startDate: memberActions[i].date, endDate: new Date(Date.now())} as Membership);
                     break;
                 }
-                if (relevantRows[j].member == currentMember && relevantRows[j].action == "leave") {
-                    memberships.push({member: currentMember, startDate: relevantRows[i].date, endDate: relevantRows[j].date});
+                if (memberActions[j].member === currentMember && memberActions[j].action === Action.Leave) {
+                    memberships.push({member: currentMember, startDate: memberActions[i].date, endDate: memberActions[j].date} as Membership);
                     break;
                 }
             }
@@ -115,39 +67,83 @@ function getMemberships(members) {
     return memberships;
 }
 
-function getRelevantTeamLogRows(members) {
-    const teamLogRows = document.getElementById("team_log").getElementsByTagName("tbody")[0].getElementsByTagName("tr");
+enum Action {
+    Leave = "leave",
+    Join = "join",
+}
+
+class MemberAction {
+    date: Date;
+    member: string;
+    action: Action;
+
+    constructor(date: Date, member: string, action: Action) {
+        this.date = date;
+        this.member = member;
+        this.action = action;
+    }
+}
+
+function getRelevantTeamLogRows(members: string[]) : MemberAction[] {
+    const teamLogRowEntries = document.evaluate(TEAM_LOG_ROWS_XPATH_EXPRESSION, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
     var relevantLogs = new Array();
     //Filter the rows for the patterns
     //date, teamMember, member_join, ...
     //date, teamMember, member_leave, ...
     //date, ..., member_kick, teamMember
-    Array.from(teamLogRows).forEach(log => {
+    for (var i = 0; i < teamLogRowEntries.snapshotLength; i++) {
+        const log = teamLogRowEntries.snapshotItem(i) as HTMLTableRowElement;
         const logElements = log.getElementsByTagName("td");
-        if (logElements.length == 4) {
-        if (logElements[2].textContent == "create") {
-            if (members.includes(logElements[1].textContent)) {
-                relevantLogs.push({date: new Date(getDateFromTeamLogEntry(logElements[0])), member: logElements[1].textContent, action: "join"});
-            }
-        } else if (logElements[2].textContent == "member_join") {
-            if (members.includes(logElements[1].textContent)) {
-                relevantLogs.push({date: new Date(getDateFromTeamLogEntry(logElements[0])), member: logElements[1].textContent, action: "join"});
-            }
-        } else if (logElements[2].textContent == "member_leave") {
-            if (members.includes(logElements[1].textContent)) {
-                relevantLogs.push({date: new Date(getDateFromTeamLogEntry(logElements[0])), member: logElements[1].textContent, action: "leave"});
-            }
-        } else if (logElements[2].textContent == "member_kick") {
-            if (members.includes(logElements[3].textContent)) {
-                relevantLogs.push({date: new Date(getDateFromTeamLogEntry(logElements[0])), member: logElements[3].textContent, action: "leave"});
-            }
+
+        if (logElements.length !== 4) {
+            continue;
         }
+
+        const action = logElements[2].textContent.substring(6);
+
+        const actingMember = logElements[1].textContent.substring(6);
+
+        const targetMember = logElements[3].textContent.substring(4);
+
+        const date = getDateFromTeamLogEntry(logElements[0]);
+
+        switch (action) {
+
+            case "create": {
+                if (members.includes(actingMember)) {
+                    relevantLogs.push(new MemberAction(date, actingMember, Action.Join));
+                }
+                break;
+            }
+
+            case "member_join": {
+                if (members.includes(actingMember)) {
+                    relevantLogs.push(new MemberAction(date, actingMember, Action.Join));
+                }
+                break;
+            }
+
+            case "member_leave": {
+                if (members.includes(actingMember)) {
+                    relevantLogs.push(new MemberAction(date, actingMember, Action.Leave));
+                }
+                break;
+            }
+
+            case "member_kick": {
+                if (members.includes(targetMember)) {
+                    relevantLogs.push(new MemberAction(date, targetMember, Action.Leave));
+                }
+                break;
+            }
+
         }
-    });
+    }
+
     return relevantLogs.sort(compareTeamLogEntries);
 }
 
-function wasMembershipDuringSeason(membership, season) {
+function wasMembershipDuringSeason(membership: Membership, season: Season) : boolean {
     if (membership.startDate < season.startDate && membership.endDate > season.startDate) {
         return true;
     }
@@ -157,95 +153,30 @@ function wasMembershipDuringSeason(membership, season) {
     return false;
 }
 
-async function getMembersPerSeason() {
-    var seasonsMembers = new Array();
-    //Get each Season with start and end date
-    const seasonRows = document.getElementById("content").getElementsByTagName("table")[1].getElementsByTagName("tbody")[0].getElementsByTagName("tr");
-    const seasons = await Promise.all(Array.from(seasonRows).map(seasonRow => {
-        const seasonUrl = seasonRow.getElementsByTagName("td")[1].getElementsByTagName("a")[0].href;
-        return getSeasonStartAndEndDates(seasonUrl);
-    }));
-    //Get each Member
-    const teamMembers = Array.from(document.getElementById("member-table").getElementsByTagName("tbody")[0].getElementsByTagName("tr")).map(member => member.getElementsByTagName("td")[2].firstChild.textContent);
-    //Get all Memberships for Members
+function getMembersPerSeason(season: Season) : string[] {
+    const teamMemberEntries = document.evaluate(MEMBER_NAMES_XPATH_EXPRESSION, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+    const teamMembers: string[] = [];
+    for (var i = 0; i < teamMemberEntries.snapshotLength; i++) {
+        teamMembers.push(teamMemberEntries.snapshotItem(i).textContent);
+    }
+
     const membershipsMembers = getMemberships(teamMembers);
+
     //Check for each season if Member had membership during timeframe update Season with Membername
-    seasons.forEach(season => {
-        var seasonMembers = new Array();
-        teamMembers.forEach(teamMember => {
-            Array.from(membershipsMembers).forEach(membership => {
-                if (membership.member == teamMember && wasMembershipDuringSeason(membership, season)) {
-                    if (!seasonMembers.includes(teamMember)) {
-                        seasonMembers.push(teamMember);
-                    }
+    var seasonMembers = new Array();
+    teamMembers.forEach(teamMember => {
+        Array.from(membershipsMembers).forEach(membership => {
+            if (membership.member === teamMember && wasMembershipDuringSeason(membership, season)) {
+                if (!seasonMembers.includes(teamMember)) {
+                    seasonMembers.push(teamMember);
                 }
-            });
+            }
         });
-        seasonsMembers.push(seasonMembers);
     });
-    return seasonsMembers;
+    return seasonMembers;
 }
 
-function formatDateToStandard(date) {
-    //Gets date in "dd mmm yyyy" format where mmm are letters
-    //Returns date in yyyy-mm-dd format where mm are digits
-    const day = date.substring(0, 2);
-    const month = date.substring(3, 6);
-    const year = date.substring(7, 11);
-    return year + "-" + getMonthNumber(month) + "-" + day;
-    return 
-}
-
-function getMonthNumber(monthName) {
-    switch (monthName) {
-        case "Jan":
-            return "01";
-        case "Feb":
-            return "02";
-        case "Mar":
-            return "03";
-        case "Apr":
-            return "04";
-        case "Mai":
-            return "05";
-        case "Jun":
-            return "06";
-        case "Jul":
-            return "07";
-        case "Aug":
-            return "08";
-        case "Sep":
-            return "09";
-        case "Okt":
-            return "10";
-        case "Nov":
-            return "11";
-        case "Dec":
-            return "12";
-        case "Dez":
-            return "12";
-        case "May":
-            return "05";
-        case "Oct":
-            return "10";
-        case "Mär":
-            return "03";
-    }
-}
-
-class SeasonBounds {
-    seasonNumber: number;
-    startDate: Date;
-    endDate: Date;
-
-    constructor(seasonNumber, startDate, endDate) {
-        this.seasonNumber = seasonNumber;
-        this.startDate = startDate;
-        this.endDate = endDate;
-    }
-}
-
-function insertFaceitEloMean(faceitEloMean) {
+function insertFaceitEloMean(faceitEloMean: number) : void {
     const faceitEloMeanH2 = document.createElement("h2");
     faceitEloMeanH2.textContent = "FACEIT Elo: " + Math.round(faceitEloMean);
     faceitEloMeanH2.title = "Durchschnittliche FACEIT Elo";
@@ -253,22 +184,27 @@ function insertFaceitEloMean(faceitEloMean) {
     teamHeader.parentNode.appendChild(faceitEloMeanH2);
 }
 
-function calcFaceitEloMean(playerInfos) {
+function calcFaceitEloMean(playerInfos: PlayerInfo[]) : number {
     const average = arr => arr.reduce((p, c) => p + c, 0) / arr.length;
     return average(playerInfos.filter(playerInfo => playerInfo.faceitInfo != null).map(playerInfo => playerInfo.faceitInfo.games.csgo.faceit_elo));
 }
 
-function improveMemberCards() {
+interface MemberCardWrapper {
+    memberCard: HTMLLIElement;
+    steamId: string;
+}
+
+function improveMemberCards() : void {
     const memberCards = document.getElementsByClassName("content-portrait-grid-l")[0].getElementsByTagName("li");
-    var memberCardWrappers = [];
+    var memberCardWrappers : MemberCardWrapper[] = [];
     for (var i = 0; i < memberCards.length; i++) {
         const memberCard = memberCards[i];
-        memberCardWrappers.push( { memberCard: memberCard, steamId: getSteamId(memberCard) } );
+        memberCardWrappers.push( { memberCard: memberCard, steamId: getSteamId(memberCard) } as MemberCardWrapper );
     }
     const steamIds = memberCardWrappers.map(memberCard => { return memberCard.steamId });
     chrome.runtime.sendMessage(
-        { contentScriptQuery: "queryPlayerInfo", steamIds: steamIds },
-        playerInfos => {
+        { contentScriptQuery: MemberRequestTypes.QueryPlayerInfos, steamIds: steamIds },
+        (playerInfos: PlayerInfo[]) => {
             playerInfos.forEach(playerInfo => {
                 const memberCardWrapper = memberCardWrappers.find(memberCard => memberCard.steamId == playerInfo.steamId);
                 inject(playerInfo, memberCardWrapper.memberCard);
@@ -279,8 +215,8 @@ function improveMemberCards() {
     );
 }
 
-function inject(playerInfo, memberCard) {
-    const steamId64 = playerInfo.steamId64;
+function inject(playerInfo: PlayerInfo, memberCard: HTMLLIElement) : void {
+    const { steamId64, steamName } = playerInfo;
 
     if (steamId64 != "") {
         const steamDiv = document.createElement("div");
@@ -290,8 +226,8 @@ function inject(playerInfo, memberCard) {
         steamDiv.style.whiteSpace = "nowrap";
         steamDiv.style.overflow = "hidden";
         const steamLink = document.createElement("a");
-        steamLink.href = `https://steamcommunity.com/profiles/${steamId64}`;
-        steamLink.textContent = playerInfo.steamName;
+        steamLink.href = getSteamLink(steamId64);
+        steamLink.textContent = steamName;
         steamLink.target = "_blank";
 
         steamDiv.appendChild(steamLink);
@@ -300,7 +236,7 @@ function inject(playerInfo, memberCard) {
     }
 
     if (playerInfo.faceitInfo != null) {
-        const faceitInfo = playerInfo.faceitInfo;
+        const { faceitInfo: { nickname, games: { csgo : { skill_level, faceit_elo } } } } = playerInfo;
 
         const eloDiv = document.createElement("div");
         eloDiv.style.textAlign = "left";
@@ -308,9 +244,9 @@ function inject(playerInfo, memberCard) {
         eloDiv.style.paddingTop = "7px";
 
         const faceitTextA = document.createElement("a");
-        faceitTextA.href = getFaceitLink(faceitInfo.nickname);
+        faceitTextA.href = getFaceitLink(nickname);
         faceitTextA.target = "_blank";
-        faceitTextA.textContent = faceitInfo.games.csgo.faceit_elo;
+        faceitTextA.textContent = faceit_elo.toString();
 
         eloDiv.textContent = "FACEIT: "
         eloDiv.appendChild(faceitTextA);
@@ -321,11 +257,11 @@ function inject(playerInfo, memberCard) {
         const faceitImg = document.createElement("img");
         faceitImg.style.width = "28px";
         faceitImg.style.height = "28px";
-        faceitImg.src = getFaceitLevel(faceitInfo.games.csgo.skill_level);
-        faceitImg.alt = faceitInfo.games.csgo.skill_level;
+        faceitImg.src = getFaceitLevel(skill_level);
+        faceitImg.alt = skill_level.toString();
         
         const faceitImageA = document.createElement("a");
-        faceitImageA.href = getFaceitLink(faceitInfo.nickname);
+        faceitImageA.href = getFaceitLink(nickname);
         faceitImageA.target = "_blank";
         faceitImageA.appendChild(faceitImg);
 
@@ -341,85 +277,14 @@ function inject(playerInfo, memberCard) {
     }
 }
 
-function getFaceitLevel(faceitLevel) {
+function getFaceitLevel(faceitLevel: number) : string {
     return `https://cdn-frontend.faceit.com/web/960/src/app/assets/images-compress/skill-icons/skill_level_${faceitLevel}_svg.svg`;
 }
 
-function getFaceitLink(name) {
+function getFaceitLink(name: string) : string {
     return `https://www.faceit.com/en/players/${name}`;
 }
 
-function getSteamId(memberCard) {
+function getSteamId(memberCard: HTMLLIElement) : string {
     return memberCard.getElementsByTagName("span")[0].textContent;
-}
-
-function getNumberOfSeasons() {
-    return document.getElementById("content").getElementsByTagName("table")[1].getElementsByTagName("tbody")[0].getElementsByTagName("tr").length;
-}
-
-function insertSeasonResultsButtons() {
-    var i = 0;
-    Array.from(document.getElementById("content").getElementsByTagName("table")[1].getElementsByTagName("tbody")[0].getElementsByTagName("tr")).forEach(element => {
-        insertSeasonResultsButtonInto(element, i++);
-    });
-}
-
-function insertSeasonResultsButtonInto(element, i) {
-    const seasonResultsButton = getSeasonResultsButton(i);
-    const seasonResultsButtonTd = document.createElement("td");
-    seasonResultsButtonTd.style.verticalAlign = "top";
-    seasonResultsButtonTd.appendChild(seasonResultsButton);
-    element.appendChild(seasonResultsButtonTd);
-}
-
-function getTeamName() {
-    const teamNameH2 = document.getElementsByTagName("h2")[0];
-    const teamName = teamNameH2.textContent.split("(")[0];
-    return teamName.trim();
-}
-
-function getTeamShorthand() {
-    const teamNameH2 = document.getElementsByTagName("h2")[0];
-    const teamShorthandRaw = teamNameH2.textContent.split("(")[1];
-    const teamShorthand = teamShorthandRaw.substring(0, teamShorthandRaw.length-1);
-    return teamShorthand.trim();
-}
-
-function removeSeasonResults(season) {
-    const table = document.getElementById("content").getElementsByTagName("table")[2];
-    const seasonsTableBody = document.getElementById("content").getElementsByTagName("table")[2].getElementsByTagName("tbody")[0];
-    table.getElementsByTagName("tbody")[0].removeChild(Array.from(table.getElementsByTagName("tr")).filter(tr => tr.parentNode == seasonsTableBody)[getActualTableIndexForSeason(season)].nextSibling);
-}
-
-function getActualTableIndexForSeason(season) {
-    const table = document.getElementById("content").getElementsByTagName("table")[2];
-    var activeSeasonResultsBefore = 0;
-    seasonResultsToggled.slice(0, season).forEach(element => {
-        if (element) {
-            activeSeasonResultsBefore++;
-        }
-    });
-    return season + activeSeasonResultsBefore;
-}
-
-function getSeasonResultsButton(season) {
-    const seasonResult = document.createElement("a");
-    seasonResult.textContent = "Ergebnisse anzeigen";
-    seasonResult.addEventListener("click", () => {
-        if (seasonResultsToggled[season] == false) {
-            const seasonUrl = "";
-            seasonResult.textContent = "Ergebnisse ausblenden";
-            seasonResultsToggled[season] = true;
-        } else {
-            removeSeasonResults(season);
-            seasonResult.textContent = "Ergebnisse anzeigen";
-            seasonResultsToggled[season] = false;
-        }
-    })
-    seasonResult.href = "javascript:void(0);"
-    const div = document.createElement("div");
-    div.className = "ylinks";
-    div.setAttribute("style", "float: left; margin-top: -3px; margin-right: 5px;");
-    div.appendChild(seasonResult);
-    return div;
 }

--- a/src/team-page/members/content.ts
+++ b/src/team-page/members/content.ts
@@ -5,8 +5,6 @@ import { MemberRequestTypes, getSteamLink, PlayerInfo } from "./background";
 const MEMBER_NAMES_XPATH_EXPRESSION = "//*[@id='container']/main/section[2]/div[3]/ul/li/a[2]/h3";
 const TEAM_LOG_ROWS_XPATH_EXPRESSION = "//*[@id='container']/main/section[4]/div/div/div[2]/table/tbody/tr";
 
-improveMemberCards();
-
 function getConsensusFromSeasonMembers(seasonMembers) {
     const teamMemberEntries = document.evaluate(MEMBER_NAMES_XPATH_EXPRESSION, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
     return Math.round(100*(seasonMembers.length/teamMemberEntries.snapshotLength));
@@ -194,7 +192,7 @@ interface MemberCardWrapper {
     steamId: string;
 }
 
-function improveMemberCards() : void {
+export function improveMemberCards() : void {
     const memberCards = document.getElementsByClassName("content-portrait-grid-l")[0].getElementsByTagName("li");
     var memberCardWrappers : MemberCardWrapper[] = [];
     for (var i = 0; i < memberCards.length; i++) {

--- a/src/team-page/members/index.ts
+++ b/src/team-page/members/index.ts
@@ -1,0 +1,4 @@
+
+import { improveMemberCards } from "./content";
+
+improveMemberCards();

--- a/src/team-page/seasons/background.ts
+++ b/src/team-page/seasons/background.ts
@@ -1,11 +1,27 @@
 
+export enum SeasonRequestType {
+    QueryApiMatches = "queryApiMatches",
+}
+
+export interface ApiMatchesRequest {
+    contentScriptQuery: typeof SeasonRequestType.QueryApiMatches;
+    teamId: number;
+}
+
+type SeasonRequest = ApiMatchesRequest;
+
 chrome.runtime.onMessage.addListener(
-    function (request, sender, sendResponse) {
-        if (request.contentScriptQuery == "apiMatches") {
-            getApiMatches(request.teamId).then(matches => {
-                sendResponse(matches);
-            })
-            return true;
+    function (request: SeasonRequest, sender, sendResponse) : boolean {
+        switch (request.contentScriptQuery) {
+            case SeasonRequestType.QueryApiMatches: {
+                getApiMatches(request.teamId).then(matches => {
+                    sendResponse(matches);
+                })
+                return true;
+            }
+            
+            default:
+                return false;
         }
     }
 );

--- a/src/team-page/seasons/content.ts
+++ b/src/team-page/seasons/content.ts
@@ -1,18 +1,20 @@
 
 import { formatDate, insertDataTablesCss, getMapImage } from "../../util/content/util";
 import { insertMapStatistics } from "../maps/content";
+// import { getConsensDiv } from "../members/content";
+import { SeasonRequestType } from "./background";
 
-class Season {
+export class Season {
     name: string;
-    startDate: number;
-    endDate: number;
+    startDate: Date;
+    endDate: Date;
     id: number;
     matches: ApiMatch[];
 
     constructor(name: string, startDate: string, endDate: string, id: number) {
         this.name = name;
-        this.startDate = Date.parse(startDate);
-        this.endDate = Date.parse(endDate);
+        this.startDate = new Date(Date.parse(startDate));
+        this.endDate = new Date(Date.parse(endDate));
         this.id = id;
         this.matches = [];
     }
@@ -84,7 +86,7 @@ function swapTeams(map: ApiMap): ApiMap {
 
 function insertMatchResults(teamId: number) {
     chrome.runtime.sendMessage(
-        { contentScriptQuery: "apiMatches", teamId },
+        { contentScriptQuery: SeasonRequestType.QueryApiMatches, teamId },
         matches => {
             for (let matchEntry in matches) {
                 let match = matches[matchEntry];
@@ -139,6 +141,7 @@ function insertSeasonResults(season: Season): void {
     seasonHeader.textContent = season.name;
     seasonDiv.appendChild(byFlashkillLink());
     seasonDiv.appendChild(seasonHeader);
+    // seasonDiv.appendChild(getConsensDiv(season));
 
     const matches = season.matches;
     const table = document.createElement("table");

--- a/src/team-page/seasons/content.ts
+++ b/src/team-page/seasons/content.ts
@@ -1,7 +1,7 @@
 
-import { formatDate, insertDataTablesCss, getMapImage } from "../../util/content/util";
+import { formatDate, getMapImage } from "../../util/content/util";
 import { insertMapStatistics } from "../maps/content";
-// import { getConsensDiv } from "../members/content";
+import { getConsensDiv } from "../members/content";
 import { SeasonRequestType } from "./background";
 
 export class Season {
@@ -37,13 +37,6 @@ const seasons = [
     new Season('Saison 2', '07 Nov 2015', '07 Feb 2016', 67),
     new Season('Saison 1', '09 Aug 2015', '25 Oct 2015', 65),
 ];
-
-const teamIdRegex = /leagues\/teams\/([0-9]+)-/;
-const teamId = Number(window.location.href.match(teamIdRegex)[1]);
-
-insertDataTablesCss();
-
-insertMatchResults(teamId);
 
 export interface ApiMatch {
     id: number;
@@ -84,7 +77,7 @@ function swapTeams(map: ApiMap): ApiMap {
     return map;
 }
 
-function insertMatchResults(teamId: number) {
+export function insertMatchResults(teamId: number) : void {
     chrome.runtime.sendMessage(
         { contentScriptQuery: SeasonRequestType.QueryApiMatches, teamId },
         matches => {
@@ -141,7 +134,7 @@ function insertSeasonResults(season: Season): void {
     seasonHeader.textContent = season.name;
     seasonDiv.appendChild(byFlashkillLink());
     seasonDiv.appendChild(seasonHeader);
-    // seasonDiv.appendChild(getConsensDiv(season));
+    seasonDiv.appendChild(getConsensDiv(season));
 
     const matches = season.matches;
     const table = document.createElement("table");
@@ -169,7 +162,7 @@ function insertSeasonResults(season: Season): void {
         if (match.maps.length > 0) {
             match.maps.forEach(map => {
                 var row = body.insertRow(0);
-                fillMapRow(row, match.id, map, match.team1, match.team2, match.createdAt);
+                fillMapRow(row, match, map);
             });
         }
     });
@@ -213,7 +206,8 @@ function insertSeasonResults(season: Season): void {
     });
 }
 
-function fillMapRow(row, matchId, map, team1, team2, matchDate) {
+function fillMapRow(row: HTMLTableRowElement, match: ApiMatch, map: ApiMap) : void {
+    const { id: matchId, team1, team2, createdAt: matchDate } = match
     const dateC = row.insertCell(-1);
     const team1C = row.insertCell(-1);
     const score1C = row.insertCell(-1);
@@ -233,17 +227,17 @@ function fillMapRow(row, matchId, map, team1, team2, matchDate) {
     team2A.href = `https://liga.99damage.de/de/leagues/teams/${team2.id}`;
     team2A.target = "_blank";
     team2C.appendChild(team2A);
-    score1C.textContent = map.score1;
-    score2C.textContent = map.score2;
+    score1C.textContent = map.score1.toString();
+    score2C.textContent = map.score2.toString();
     mapC.textContent = map.map;
     const mapImageLink = getMapImage(map.map);
-    mapC.style = `
+    mapC.setAttribute("style", `
         background-image:url(${mapImageLink});
         text-align:center;
         background-size:cover;
         color:#fff;
         text-shadow:0 0 4px #000, 0px 0 4px #000, 0px 0 3px #000;
-    `;
+    `);
     const linkA = document.createElement("a");
     linkA.href = `https://liga.99damage.de/de/leagues/matches/${matchId}`;
     linkA.target = "_blank";

--- a/src/team-page/seasons/index.ts
+++ b/src/team-page/seasons/index.ts
@@ -1,0 +1,10 @@
+
+import { insertDataTablesCss } from "../../util/content/util";
+import { insertMatchResults } from "./content";
+
+const teamIdRegex = /leagues\/teams\/([0-9]+)-/;
+const teamId = Number(window.location.href.match(teamIdRegex)[1]);
+
+insertDataTablesCss();
+
+insertMatchResults(teamId);

--- a/src/util/background/fetchCached.ts
+++ b/src/util/background/fetchCached.ts
@@ -1,9 +1,10 @@
+
 const DEFAULT_CACHE_TIME = 3600;
 const ONE_DAY_IN_SECONDS = 86400;
 const ONE_WEEK_IN_SECONDS = ONE_DAY_IN_SECONDS * 7;
 const MATCH_DATE_XPATH_EXPRESSION = "/html/body/div[1]/main/section[1]/div/div[2]/div[1]/span/text()";
 
-export async function fetchCached(url, cacheValidCondition = defaultCacheValidCondition, extractor = response => response.text(), header = null) : Promise<string> {
+export async function fetchCached<T>(url: string, cacheValidCondition = defaultCacheValidCondition, extractor: (Response) => Promise<T> = response => response.text(), header = null) : Promise<T> {
     return new Promise((resolve, reject) => {
         chrome.storage.local.get(url, cachedItems => {
             if (cachedItems[url]) {
@@ -24,14 +25,6 @@ export async function fetchCached(url, cacheValidCondition = defaultCacheValidCo
             });
         });
     });
-}
-
-export function faceitExtractor(faceitResponse) {
-    if (faceitResponse.ok) {
-        return faceitResponse.json();
-    } else {
-        return null;
-    }
 }
 
 export function cacheOnlyPastMatches(cacheResponse) {

--- a/src/util/content/util.ts
+++ b/src/util/content/util.ts
@@ -8,7 +8,6 @@ const mapImageOverpass = "https://cdn0.gamesports.net/map_thumbs_big/295.jpg?0";
 const mapImageVertigo = "https://cdn0.gamesports.net/map_thumbs_big/417.jpg?1554321447";
 const mapImageNuke = "https://cdn0.gamesports.net/map_thumbs_big/91.jpg?1457434550";
 
-
 export function insertDataTablesCss() : void {
     const datatablescss = document.createElement("link");
     datatablescss.setAttribute("rel", "stylesheet");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,8 +29,8 @@ const backgroundConfig = {
 
 const contentScripts = [
     'content.ts',
-    'team-page/seasons/content.ts',
-    'team-page/members/content.ts',
+    'team-page/seasons/index.ts',
+    'team-page/members/index.ts',
 ];
 
 const contentScriptConfigs = contentScripts.map(contentScriptPath => {


### PR DESCRIPTION
Adjust the old implementation of the consensus calculation to the new league page and include the result in the season results headers to resolve #8.

I had to adjust the directory structure slighly. The consensus calculation is based on the members and thus it lies in the `members/content.ts` script. However, we include it in the season results. Importing the function from the members content script, results in the function calls in the members script being executed again and would result in `improveMemberCards` being called twice.
In the new setup, we have `index.ts` files that actually call the imported functions and the content scripts include only definitions.

With all the added typing, interfaces and classes, there will be more refactoring necessary later but it was not the main focus for this PR. 
